### PR TITLE
docs: add installation option via OpenUPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 <h1 align="center">Welcome to com.gameframe.giphy 👋</h1>
 <p>
   <img alt="Version" src="https://img.shields.io/badge/version-1.0.0-blue.svg?cacheSeconds=2592000" />
+  <a href="https://openupm.com/packages/com.gameframe.giphy/">
+    <img src="https://img.shields.io/npm/v/com.gameframe.giphy?label=openupm&amp;registry_uri=https://package.openupm.com" />
+  </a>
   <a href="https://twitter.com/coryleach">
     <img alt="Twitter: coryleach" src="https://img.shields.io/twitter/follow/coryleach.svg?style=social" target="_blank" />
   </a>
@@ -12,7 +15,16 @@
 
 ## Quick Package Install
 
+#### Using OpenUPM
+
+The package is available on the [openupm registry](https://openupm.com/packages/com.gameframe.giphy/). It's recommended to install it via [openupm-cli](https://github.com/openupm/openupm-cli#openupm-cli).
+
+```
+openupm add com.littlebigfun.addressable-importer
+```
+
 #### Using UnityPackageManager (for Unity 2019.3 or later)
+
 Open the package manager window (menu: Window > Package Manager)<br/>
 Select "Add package from git URL...", fill in the pop-up with the following link:<br/>
 https://github.com/coryleach/UnityGiphy.git#1.0.0<br/>


### PR DESCRIPTION
Hi @coryleach,

Favo from OpenUPM. Your package is available at https://openupm.com/packages/com.gameframe.giphy/. Please consider merging the docs update.